### PR TITLE
Add split docs for run and HLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ import tigerbx
 tigerbx.hlc('T1w_dir', 'outputdir')
 ```
 
+See [run usage](doc/run.md) and [HLC usage](doc/hlc.md) for a complete description of these APIs.
+
 ### Registration and VBM
 
 See [registration instructions](doc/reginstruction.md) for detailed usage guidelines on the various methods.

--- a/doc/hlc.md
+++ b/doc/hlc.md
@@ -1,0 +1,35 @@
+# TigerBx: `hlc` Module
+
+This guide describes how to consolidate labels using `tigerbx.hlc`.
+
+## Function
+
+`hlc(input, output=None, model=None, save='all', GPU=False, gz=True, patch=False)`
+
+The function merges segmentation labels into a hierarchy and can optionally output cortical thickness or CSF/GM/WM probability maps.
+
+### Parameters
+
+- **input**: Path to a NIfTI file, directory, or wildcard pattern.
+- **output**: Destination directory for results. Defaults to the input location if not specified.
+- **model**: Custom model overrides in dictionary form. Leave `None` for default weights.
+- **save**: Letters indicating which outputs to save (`b`=brain, `m`=mask, `h`=HLC labels, `c`=cortical thickness, `C`=CSF/GM/WM). Use `'all'` to generate everything.
+- **GPU**: Use GPU if `True`.
+- **gz**: Save files in `.nii.gz` format.
+- **patch**: Enable patch‑based inference.
+
+### Example
+
+```python
+import tigerbx
+
+# Run HLC with default settings and save brain mask + HLC labels
+result = tigerbx.hlc('T1w_dir', 'out_dir', save='bh', GPU=True)
+```
+
+The function returns either a dictionary of NIfTI objects (single file) or a list of output filenames when processing multiple inputs.
+
+---
+
+For a list of label IDs used in segmentation, see [Label definitions](seglabel.md). For registration tools and VBM analyses, refer to [registration instructions](reginstruction.md).
+

--- a/doc/run.md
+++ b/doc/run.md
@@ -1,0 +1,43 @@
+# TigerBx: `run` Module
+
+This guide explains how to use the Python API `tigerbx.run` for brain extraction and related segmentation tasks.
+
+## Function
+
+`run(argstring, input, output=None, model=None)`
+
+The `argstring` argument is a string of flags specifying which models to apply. Multiple flags can be combined, e.g. `'bd'` for brain extraction plus deep gray matter segmentation.
+
+### Common Flags
+
+| Flag | Description |
+| ---- | ----------- |
+| `b`  | Brain extraction (default if no other flags are given) |
+| `m`  | Brain mask only |
+| `a`  | ASEG tissue segmentation |
+| `d`  | Deep gray matter mask |
+| `k`  | DKT cortical parcellation |
+| `c`  | Cortical thickness map |
+| `C`  | CSF/GM/WM probability maps |
+| `w`  | White matter parcellation |
+| `W`  | White matter hypointensity mask |
+| `t`  | Tumor segmentation |
+| `q`  | Save a QC score to file |
+| `z`  | Force `.nii.gz` output |
+| `p`  | Enable patch inference |
+| `g`  | Use GPU for inference |
+| `clean_onnx` | Delete downloaded model files |
+| `encode` / `decode` | Convert volumes to latent space or back |
+
+### Example
+
+```python
+import tigerbx
+
+# Perform brain extraction and deep GM segmentation
+# Equivalent to running flags "bd" on the input file
+result = tigerbx.run('bd', 'T1w.nii.gz', 'out_dir')
+```
+
+If a directory or wildcard pattern is provided as the `input`, all matching files are processed. When `output` is `None`, results are saved next to each input file.
+


### PR DESCRIPTION
## Summary
- split documentation for `tigerbx.run` and `tigerbx.hlc` into separate files
- update README link accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846e8d65e44832c8578b421a1a1aa52