### PR TITLE
Add docs authors and CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ import tigerbx
 tigerbx.hlc('T1w_dir', 'outputdir')
 ```
 
+```bash
+tiger hlc T1w_dir -o outputdir
+```
+
 See [HLC usage](doc/hlc.md) for a complete description of these APIs.
 
 ### Registration and VBM
@@ -88,6 +92,11 @@ tigerbx.reg('v', r'C:\T1w_dir\**\*.nii.gz', r'C:\output_dir')
 # Apply warp field
 tigerbx.transform(r'C:\T1w_dir\moving.nii.gz', r'C:\T1w_dir\warp.npz', r'C:\output_dir', interpolation='nearest')
 ```
+```bash
+tiger reg -r C:\T1w_dir -o C:\output_dir -T template.nii.gz --affine_type C2FViT
+tiger reg -F C:\T1w_dir -o C:\output_dir --affine_type ANTs
+tiger reg -v C:\T1w_dir\**\*.nii.gz -o C:\output_dir --affine_type C2FViT
+```
 See [registration instructions](doc/reginstruction.md) for detailed usage guidelines on the various methods.
 
 ### Generative Displacement Mapping (GDM)
@@ -104,7 +113,7 @@ tigerbx.gdm(r'C:\EPI_dir', r'C:\output_dir', b0_index=0)
 
 ### NERVE Embedding Pipeline
 
-NERVE encodes hippocampus and amygdala patches into latent vectors using a variational autoencoder. The embeddings were developed by **Pei-Shin Chen** for downstream neuroimaging tasks such as Alzheimer\u2019s disease detection.
+NERVE encodes hippocampus and amygdala patches into latent vectors using a variational autoencoder. These embeddings can be used for downstream neuroimaging tasks such as Alzheimer\u2019s disease detection.
 
 ```python
 # Encode and decode a T1-weighted image

--- a/doc/hlc.md
+++ b/doc/hlc.md
@@ -1,6 +1,7 @@
 # TigerBx: `hlc` Module
 
 This guide describes how to consolidate labels using `tigerbx.hlc`.
+The HLC module was developed by **Pin-Chuan Chen**.
 
 ## Function
 
@@ -25,6 +26,12 @@ import tigerbx
 
 # Run HLC with default settings and save brain mask + HLC labels
 result = tigerbx.hlc('T1w_dir', 'out_dir', save='bh', GPU=True)
+```
+
+### CLI Example
+
+```bash
+tiger hlc T1w_dir -o out_dir --save bh -g
 ```
 
 The function returns either a dictionary of NIfTI objects (single file) or a list of output filenames when processing multiple inputs.

--- a/doc/reginstruction.md
+++ b/doc/reginstruction.md
@@ -1,6 +1,7 @@
 # TigerBx: Brain Image Registration and VBM Pipeline
 
 This module offers flexible tools for brain image registration and voxel‑based morphometry (VBM). It supports a variety of affine and nonlinear registration approaches, including both deep‑learning and classical algorithms.
+The VBM and registration pipeline was developed by **Pei-Mao Sun**.
 
 ---
 
@@ -58,6 +59,13 @@ tigerbx.transform(
     r'C:\\output_dir',
     interpolation='nearest'
 )
+```
+### CLI Example
+
+```bash
+tiger reg -r C:\T1w_dir -o C:\output_dir -T template.nii.gz --affine_type C2FViT
+tiger reg -F C:\T1w_dir -o C:\output_dir --affine_type ANTs
+tiger reg -v C:\T1w_dir\**\*.nii.gz -o C:\output_dir --affine_type C2FViT
 ```
 
 ---


### PR DESCRIPTION
## Summary
- document CLI commands for HLC and registration modules
- credit Pin-Chuan Chen for the HLC module
- credit Pei-Mao Sun for the registration/VBM pipeline
- remove personal names from README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a43d30b30832c8817d1a4815ca9fd