### PR TITLE
Add PyInstaller hook for onnxruntime

### DIFF
--- a/.github/workflows/compile6.yml
+++ b/.github/workflows/compile6.yml
@@ -1,0 +1,93 @@
+name: Compile6
+
+on:
+  workflow_dispatch:        # 手動觸發
+
+permissions:
+  contents: write           # 建立 Release 需要
+
+jobs:
+# ============================================================
+# 1. Build ── 針對三大 OS 編譯並產生可執行檔 & ZIP
+# ============================================================
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        py: ['tiger']        # 主要執行入口 (tiger.py)
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+
+    - name: Derive short commit SHA
+      id: vars
+      shell: bash
+      run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9"
+
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+        pip install pyinstaller onnxruntime
+
+    - name: PyInstaller
+      shell: bash
+      run: |
+        pyinstaller -c -p ./tigerbx \
+          --additional-hooks-dir=./pyinstaller_hooks \
+          --icon=./tigerbx/exe/ico.ico \
+          -F ./tigerbx/${{ matrix.py }}.py
+
+    - name: Package ZIP
+      shell: bash
+      run: |
+        mkdir release
+        # Windows 用 copy；其他平台用 mv
+        if [[ "$RUNNER_OS" == "Windows" ]]; then
+          cp dist/* release/
+          powershell -Command "Compress-Archive -Path release/* -DestinationPath release-${{ matrix.os }}-${{ env.SHORT_SHA }}.zip"
+        else
+          mv dist/* release/
+          zip -r "release-${{ matrix.os }}-${{ env.SHORT_SHA }}.zip" release/
+        fi
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: binaries-${{ matrix.os }}
+        path: release-${{ matrix.os }}-${{ env.SHORT_SHA }}.zip
+
+# ============================================================
+# 2. Release ── 合併所有 zip 並建立 GitHub Release
+# ============================================================
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    # 直接下載所有 artifacts，並展平到 artifacts/ 目錄
+    - name: Download all build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true      # 🔑 將多個 artifact 內容合併
+        path: artifacts
+
+    - name: List downloaded files
+      run: ls -lh artifacts
+
+    - name: Create draft GitHub Release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: v${{ github.run_number }}
+        name: Release ${{ github.run_number }}
+        draft: true
+        artifacts: artifacts/*.zip
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/pyinstaller_hooks/hook-onnxruntime.py
+++ b/pyinstaller_hooks/hook-onnxruntime.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+# Collect all shared libraries from onnxruntime
+binaries = collect_dynamic_libs('onnxruntime')


### PR DESCRIPTION
## Summary
- use a PyInstaller hook so the onnxruntime shared libraries are automatically bundled
- call the hook in the Compile6 workflow

## Testing
- `python -m pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=42)*

------
https://chatgpt.com/codex/tasks/task_e_684a4aaa50a0832ca97a7f89e3b0be56